### PR TITLE
add interface to abstract object instantiation

### DIFF
--- a/frontend/app/.server/domain/mappers/letter.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/letter.dto.mapper.ts
@@ -6,6 +6,10 @@ export interface LetterDtoMapper {
   mapPdfEntityToString(pdfEntity: PdfEntity): string;
 }
 
+export function getLetterDtoMapper(): LetterDtoMapper {
+  return new DefaultLetterDtoMapper();
+}
+
 export class DefaultLetterDtoMapper implements LetterDtoMapper {
   mapLetterEntitiesToLetterDtos(letterEntities: readonly LetterEntity[]): readonly LetterDto[] {
     return letterEntities.map((letterEntity) => this.mapLetterEntityToLetterDto(letterEntity));

--- a/frontend/app/.server/domain/repositories/letter.repository.ts
+++ b/frontend/app/.server/domain/repositories/letter.repository.ts
@@ -1,6 +1,8 @@
 import type { LetterEntity, PdfEntity } from '~/.server/domain/entities/letter.entity';
 import type { ServerEnvironment } from '~/.server/environment';
+import { serverEnvironment } from '~/.server/environment';
 import type { HttpClient } from '~/.server/http/http-client';
+import { getHttpClient } from '~/.server/http/http-client';
 import { LogFactory } from '~/.server/logging';
 // TODO: Update this file?
 import getPdfByLetterIdJson from '~/.server/resources/cct/get-pdf-by-letter-id.json';
@@ -44,6 +46,11 @@ export interface LetterRepository {
   checkHealth(): Promise<void>;
 }
 
+export function getLetterRepository(): LetterRepository {
+  return serverEnvironment.ENABLE_MOCK_LETTER_SERVICE
+    ? new MockLetterRepository()
+    : new DefaultLetterRepository(serverEnvironment, getHttpClient());
+}
 export class DefaultLetterRepository implements LetterRepository {
   private readonly log;
   private readonly serverConfig: Pick<
@@ -75,8 +82,7 @@ export class DefaultLetterRepository implements LetterRepository {
     this.log = LogFactory.getLogger(import.meta.url);
     this.serverConfig = serverConfig;
     this.httpClient = httpClient;
-    // TODO: Fix this endpoint
-    this.baseUrl = `${this.serverConfig.CCT_API_BASE_URI}/dental-care/client-letters/cct/v1`;
+    this.baseUrl = `${this.serverConfig.CCT_API_BASE_URI}/client-correspondence/letter-retrieval/cct/v1`;
   }
 
   async findLettersBySin(sin: string): Promise<readonly LetterEntity[]> {

--- a/frontend/app/.server/domain/services/audit.service.ts
+++ b/frontend/app/.server/domain/services/audit.service.ts
@@ -13,6 +13,10 @@ export interface AuditService {
   createAudit(eventId: string, auditDetails?: AuditDetails): void;
 }
 
+export function getAuditService(): AuditService {
+  return new DefaultAuditService();
+}
+
 export class DefaultAuditService implements AuditService {
   private readonly log;
 

--- a/frontend/app/.server/domain/services/letter.service.ts
+++ b/frontend/app/.server/domain/services/letter.service.ts
@@ -2,8 +2,11 @@ import { sort } from 'moderndash';
 
 import type { LetterDto, LettersRequestDto, PdfRequestDto } from '~/.server/domain/dtos/letter.dto';
 import type { LetterDtoMapper } from '~/.server/domain/mappers/letter.dto.mapper';
+import { getLetterDtoMapper } from '~/.server/domain/mappers/letter.dto.mapper';
 import type { LetterRepository } from '~/.server/domain/repositories/letter.repository';
+import { getLetterRepository } from '~/.server/domain/repositories/letter.repository';
 import type { AuditService } from '~/.server/domain/services/audit.service';
+import { getAuditService } from '~/.server/domain/services/audit.service';
 import { LogFactory } from '~/.server/logging';
 
 export interface LetterService {
@@ -22,6 +25,13 @@ export interface LetterService {
    * @returns A Promise that resolves to the PDF data as a base64-encoded string representing the bytes.
    */
   getPdfByLetterId(pdfRequestDto: PdfRequestDto): Promise<string>;
+}
+
+export function getLetterService(): LetterService {
+  const mapper = getLetterDtoMapper();
+  const auditService = getAuditService();
+  const repo = getLetterRepository();
+  return new DefaultLetterService(mapper, repo, auditService);
 }
 
 export class DefaultLetterService implements LetterService {

--- a/frontend/app/.server/environment/cct-api.ts
+++ b/frontend/app/.server/environment/cct-api.ts
@@ -11,6 +11,7 @@ export const defaults = {
   HTTP_PROXY_URL: '',
   HTTP_PROXY_TLS_TIMEOUT: 30 * 1000,
   HEALTH_PLACEHOLDER_REQUEST_VALUE: 'CDB_HEALTH_CHECK',
+  ENABLE_MOCK_LETTER_SERVICE: true,
 } as const;
 
 export const cctApi = v.object({
@@ -22,4 +23,5 @@ export const cctApi = v.object({
   HTTP_PROXY_URL: v.optional(v.string(), defaults.HTTP_PROXY_URL),
   HTTP_PROXY_TLS_TIMEOUT: v.optional(v.number(), defaults.HTTP_PROXY_TLS_TIMEOUT),
   HEALTH_PLACEHOLDER_REQUEST_VALUE: v.optional(v.string(), defaults.HEALTH_PLACEHOLDER_REQUEST_VALUE),
+  ENABLE_MOCK_LETTER_SERVICE: v.optional(v.boolean(), defaults.ENABLE_MOCK_LETTER_SERVICE),
 });

--- a/frontend/app/.server/http/http-client.ts
+++ b/frontend/app/.server/http/http-client.ts
@@ -97,6 +97,10 @@ export interface HttpClient {
   instrumentedFetch(metricPrefix: string, input: RequestInfo | URL, options?: InstrumentedFetchOptions): Promise<Response>;
 }
 
+export function getHttpClient(): HttpClient {
+  return new DefaultHttpClient();
+}
+
 export class DefaultHttpClient implements HttpClient {
   private readonly log;
 


### PR DESCRIPTION
Add a `getLetterService()` function so that calling modules don't need to know the guts of the service to instantiate it