### PR TITLE
fix(frontend): remove cache-busting for client-env and translations

### DIFF
--- a/frontend/app/.server/express/middleware.ts
+++ b/frontend/app/.server/express/middleware.ts
@@ -28,7 +28,8 @@ function shouldIgnore(ignorePatterns: string[], path: string): boolean {
  */
 export function caching(environment: ServerEnvironment): RequestHandler {
   const ignorePatterns: string[] = [
-    /* intentionally left blank */
+    '/api/client-env', //
+    '/api/translations',
   ];
 
   return (request, response, next) => {


### PR DESCRIPTION
Commit 7a11e2a0863d17da1a9c5687a9a531c9ce5d5683 broke client-env and translation caching. This PR fixes that regression.