### PR TITLE
Fix/logout timer

### DIFF
--- a/frontend/app/.server/environment/client.ts
+++ b/frontend/app/.server/environment/client.ts
@@ -14,7 +14,7 @@ export const defaults = {
   BUILD_VERSION: '0.0.0-000000-00000000',
   I18NEXT_DEBUG: 'false',
   SESSION_TIMEOUT_PROMPT_SECONDS: (5 * 60).toString(),
-  SESSION_TIMEOUT_SECONDS: (15 * 60).toString(),
+  SESSION_TIMEOUT_SECONDS: (19 * 60).toString(),
   MSCA_BASE_URL: 'http://localhost:3000',
   ECAS_BASE_URL: 'http://localhost:3000',
 } as const;

--- a/frontend/app/.server/environment/client.ts
+++ b/frontend/app/.server/environment/client.ts
@@ -14,7 +14,7 @@ export const defaults = {
   BUILD_VERSION: '0.0.0-000000-00000000',
   I18NEXT_DEBUG: 'false',
   SESSION_TIMEOUT_PROMPT_SECONDS: (5 * 60).toString(),
-  SESSION_TIMEOUT_SECONDS: (19 * 60).toString(),
+  SESSION_TIMEOUT_SECONDS: (15 * 60).toString(),
   MSCA_BASE_URL: 'http://localhost:3000',
   ECAS_BASE_URL: 'http://localhost:3000',
 } as const;

--- a/gitops/nonprod/overlays/dev/configs/frontend.conf
+++ b/gitops/nonprod/overlays/dev/configs/frontend.conf
@@ -122,7 +122,7 @@ SESSION_KEY_PREFIX=
 SESSION_TIMEOUT_PROMPT_SECONDS=
 
 # the time before a user is considered idle in seconds (default: 19 minutes)
-SESSION_TIMEOUT_SECONDS=
+SESSION_TIMEOUT_SECONDS=900
 
 
 

--- a/gitops/nonprod/overlays/int/configs/frontend.conf
+++ b/gitops/nonprod/overlays/int/configs/frontend.conf
@@ -126,7 +126,7 @@ SESSION_KEY_PREFIX=SESSION:INT:
 SESSION_TIMEOUT_PROMPT_SECONDS=
 
 # the time before a user is considered idle in seconds (default: 19 minutes)
-SESSION_TIMEOUT_SECONDS=
+SESSION_TIMEOUT_SECONDS=900
 
 
 

--- a/gitops/nonprod/overlays/local/configs/frontend.conf
+++ b/gitops/nonprod/overlays/local/configs/frontend.conf
@@ -98,7 +98,7 @@ SESSION_KEY_PREFIX=
 SESSION_TIMEOUT_PROMPT_SECONDS=
 
 # the time before a user is considered idle in seconds (default: 19 minutes)
-SESSION_TIMEOUT_SECONDS=
+SESSION_TIMEOUT_SECONDS=900
 
 
 

--- a/gitops/nonprod/overlays/staging/configs/frontend.conf
+++ b/gitops/nonprod/overlays/staging/configs/frontend.conf
@@ -126,7 +126,7 @@ SESSION_KEY_PREFIX=SESSION:STAGING:
 SESSION_TIMEOUT_PROMPT_SECONDS=
 
 # the time before a user is considered idle in seconds (default: 19 minutes)
-SESSION_TIMEOUT_SECONDS=
+SESSION_TIMEOUT_SECONDS=900
 
 
 

--- a/gitops/prod/overlay/configs/frontend/config.conf
+++ b/gitops/prod/overlay/configs/frontend/config.conf
@@ -126,7 +126,7 @@ SESSION_KEY_PREFIX=
 SESSION_TIMEOUT_PROMPT_SECONDS=
 
 # the time before a user is considered idle in seconds (default: 19 minutes)
-SESSION_TIMEOUT_SECONDS=
+SESSION_TIMEOUT_SECONDS=900
 
 
 


### PR DESCRIPTION
Override the session timeout to 15 minutes for all environments.